### PR TITLE
Adding scale down when hovering over deleteView

### DIFF
--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/MultiTouchListener.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/MultiTouchListener.java
@@ -90,6 +90,8 @@ class MultiTouchListener implements OnTouchListener {
         scale = Math.max(info.minimumScale, Math.min(info.maximumScale, scale));
         view.setScaleX(scale);
         view.setScaleY(scale);
+        ((ViewInfo)view.getTag()).setDefaultScaleX(scale);
+        ((ViewInfo)view.getTag()).setDefaultScaleY(scale);
 
         float rotation = adjustAngle(view.getRotation() + info.deltaAngle);
         view.setRotation(rotation);
@@ -161,12 +163,37 @@ class MultiTouchListener implements OnTouchListener {
                 firePhotoEditorSDKListener(view, true);
                 break;
             case MotionEvent.ACTION_MOVE:
-                int pointerIndexMove = event.findPointerIndex(mActivePointerId);
-                if (pointerIndexMove != -1) {
-                    float currX = event.getX(pointerIndexMove);
-                    float currY = event.getY(pointerIndexMove);
-                    if (!mScaleGestureDetector.isInProgress()) {
-                        adjustTranslation(view, currX - mPrevX, currY - mPrevY);
+                ViewInfo viewInfo = (ViewInfo) view.getTag();
+                if (deleteView != null  && isViewInBounds(deleteView, x, y) && !viewInfo.isDeleting()) {
+                    viewInfo.setDeleting(true);
+
+                    view.setPivotX(view.getMeasuredWidth()/2);
+                    view.setPivotY(view.getMeasuredHeight()/2);
+                    view.animate()
+                            //Set x,y to delete view center - view.width/height
+                            .x(((deleteView.getX() + deleteView.getWidth()/2) - view.getWidth()/2))
+                            .y(((deleteView.getY() + deleteView.getHeight()/2) - view.getHeight()/2))
+                            .scaleX(viewInfo.getScaledDownX())
+                            .scaleY(viewInfo.getScaledDownY())
+                            .setDuration(500)
+                            .start();
+                } else if (deleteView != null && !isViewInBounds(deleteView, x, y) && viewInfo.isDeleting()) {
+                    viewInfo.setDeleting(false);
+                    view.animate().cancel();
+                    view.animate()
+                            .scaleX(viewInfo.getDefaultScaleX())
+                            .scaleY(viewInfo.getDefaultScaleY())
+                            .setDuration(300)
+                            .start();
+
+                } else if(deleteView != null && !isViewInBounds(deleteView, x, y) && !viewInfo.isDeleting()){
+                    int pointerIndexMove = event.findPointerIndex(mActivePointerId);
+                    if (pointerIndexMove != -1) {
+                        float currX = event.getX(pointerIndexMove);
+                        float currY = event.getY(pointerIndexMove);
+                        if (!mScaleGestureDetector.isInProgress()) {
+                            adjustTranslation(view, currX - mPrevX, currY - mPrevY);
+                        }
                     }
                 }
                 break;
@@ -395,6 +422,64 @@ class MultiTouchListener implements OnTouchListener {
         view.getLocationOnScreen(location);
         outRect.offset(location[0], location[1]);
         return outRect.contains(x, y);
+    }
+
+    /**
+     *    Method that converts the motion event x,y to actually image coordinates
+     *    Takes into consideration scale and rotation.
+     *
+     *    NB!: This method is custom made for this PhotoEditor as it takes into consideration the border around the imageView
+     *    If you want to use this method in a scenario where the view parameter is the ImageView itself you need to remove all the "border" handling.
+     * @param view
+     * @param event
+     */
+    private Point getBitmapHitXYForMotionEvent(View view, MotionEvent event) {
+        ImageView image = view.findViewById(R.id.imgPhotoEditorImage);
+        FrameLayout border = view.findViewById(R.id.frmBorder);
+        Bitmap bitmap = ((BitmapDrawable) image.getDrawable()).getBitmap();
+
+        int eventX = (int) event.getX();
+        int eventY = (int) event.getY();
+
+        Rect imageRect = new Rect();
+        image.getHitRect(imageRect);
+
+        //Get rect of border
+        Rect borderRect = new Rect();
+        border.getHitRect(borderRect);
+
+        //The eventX and Y for the actual image (discluding the frame and any views around it)
+        int imageEventX = eventX - (imageRect.left + borderRect.left);
+        int imageEventY = eventY - (imageRect.top + borderRect.top);
+
+        float scaleFactorX = (float) bitmap.getWidth() / (float) image.getWidth();
+        float scaleFactorY = (float) bitmap.getHeight() / (float) image.getHeight();
+
+        //To get the coordinates of the click relative to the bitmap we use an scaled image matrix
+        float[] imageEventXY = new float[]{imageEventX, imageEventY};
+        Matrix invertMatrix = new Matrix();
+        ((ImageView) image).getImageMatrix().invert(invertMatrix);
+        invertMatrix.setScale(scaleFactorX, scaleFactorY);
+        invertMatrix.mapPoints(imageEventXY);
+
+        int bitmapX = (int) imageEventXY[0];
+        int bitmapY = (int) imageEventXY[1];
+
+        //Limit x, y range within bitmap
+        if (bitmapX < 0) {
+            bitmapX = 0;
+        } else if (bitmapX > bitmap.getWidth() - 1) {
+            bitmapX = bitmap.getWidth() - 1;
+        }
+
+        if (bitmapY < 0) {
+            bitmapY = 0;
+        } else if (bitmapY > bitmap.getHeight() - 1) {
+            bitmapY = bitmap.getHeight() - 1;
+        }
+
+        Log.d("MTL", "BITMAP X:" + bitmapX + " ,Y:" + bitmapY);
+        return new Point(bitmapX, bitmapY);
     }
 
     private boolean isImageWithBitmapDrawable(View view){

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
@@ -115,6 +115,8 @@ public class PhotoEditor implements BrushViewChangeListener, MultiTouchListener.
             frmBorder.setTag(false);
         }
 
+        imageRootView.setTag(new ViewInfo(imageRootView));
+
         imageRootView.setOnTouchListener(multiTouchListener);
 
         addViewToParent(imageRootView, ViewType.IMAGE);
@@ -182,6 +184,8 @@ public class PhotoEditor implements BrushViewChangeListener, MultiTouchListener.
             frmBorder.setBackgroundResource(0);
             frmBorder.setTag(false);
         }
+
+        textRootView.setTag(new ViewInfo(textRootView));
 
         textRootView.setOnTouchListener(multiTouchListener);
         addViewToParent(textRootView, ViewType.TEXT);
@@ -273,6 +277,8 @@ public class PhotoEditor implements BrushViewChangeListener, MultiTouchListener.
             frmBorder.setBackgroundResource(0);
             frmBorder.setTag(false);
         }
+
+        emojiRootView.setTag(new ViewInfo(emojiRootView));
 
         emojiRootView.setOnTouchListener(multiTouchListener);
         addViewToParent(emojiRootView, ViewType.EMOJI);

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/ViewInfo.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/ViewInfo.java
@@ -1,0 +1,66 @@
+package ja.burhanrashid52.photoeditor;
+
+import android.view.View;
+
+/**
+ * <p>
+ * This is custom drawing view used to do painting on user touch events it it will paint on canvas
+ * as per attributes provided to the paint
+ * </p>
+ *
+ * @author <a href="https://github.com/burhanrashid52">Burhanuddin Rashid</a>
+ * @version 0.1.1
+ * @since 12/1/18
+ */
+public class ViewInfo {
+
+    private boolean isDeleting = false;
+
+    private final int SCALE_DOWN_FACTOR = 8;
+
+    private float defaultScaleX = 0;
+    private float defaultScaleY = 0;
+    private float scaleDownX = 0;
+    private float scaleDownY = 0;
+
+    public ViewInfo(View view) {
+        defaultScaleX = view.getScaleX();
+        defaultScaleY = view.getScaleY();
+        scaleDownX = defaultScaleX/SCALE_DOWN_FACTOR;
+        scaleDownY = defaultScaleY/SCALE_DOWN_FACTOR;
+
+    }
+
+    public void setDefaultScaleX(float defaultScaleX) {
+        this.defaultScaleX = defaultScaleX;
+
+    }
+
+    public void setDefaultScaleY(float defaultScaleY) {
+        this.defaultScaleY = defaultScaleY;
+    }
+
+    public boolean isDeleting() {
+        return isDeleting;
+    }
+
+    public void setDeleting(boolean deleting) {
+        isDeleting = deleting;
+    }
+
+    public float getDefaultScaleX() {
+        return defaultScaleX;
+    }
+
+    public float getDefaultScaleY() {
+        return defaultScaleY;
+    }
+
+    public float getScaledDownX(){
+        return scaleDownX;
+    }
+    public float getScaledDownY(){
+        return scaleDownY;
+    }
+
+}


### PR DESCRIPTION
- Added code in the MultiTouchListener to support scaling down views when they enter the deleteView view. The added code centers the view over the delete view and scales it down. There is still some optimization that could be done as the first time the view is moved over the deleteView one get some weird view movement.

- Added a ViewInfo class that contains all the information on the view. This is used to store the default scale of the view before scaling it down so that it can be used to scale it back up to correct size. This class can also be used to hold stickers meta data in the future.