### PR TITLE
Add fix for issue where transparent pixel was not detected correctly

### DIFF
--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/MultiTouchListener.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/MultiTouchListener.java
@@ -250,17 +250,11 @@ class MultiTouchListener implements OnTouchListener {
         Bitmap bitmap = ((BitmapDrawable) image.getDrawable()).getBitmap();
 //        Bitmap drawableBitmap = bitmap.copy(bitmap.getConfig(), true);
 
-
         int eventX = (int)event.getX();
         int eventY = (int)event.getY();
 
         Rect imageRect = new Rect();
         image.getHitRect(imageRect);
-
-        //Check if you hit outside the image. If you hit the frame around the view we say that that you hit a transparent pixel.
-        if(!imageRect.contains(eventX, eventY)){
-            return false;
-        }
 
         //Get rect of border
         Rect borderRect = new Rect();


### PR DESCRIPTION
- It seems like the imageRect check checks a too small rect, the code checking this is not really needed anymore as we do check in "isPixelOpaque" that the x,y is inside the bitmap. Therefore i remove this "if" check.