### PR TITLE
Add fix for issue where transparent pixel was not detected correctly

### DIFF
--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/MultiTouchListener.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/MultiTouchListener.java
@@ -263,6 +263,14 @@ class MultiTouchListener implements OnTouchListener {
         //Enable to enabled radius to scale together with scaling
 //        mVariableTransparentPixelsClickThroughRadius = (int)(mTransparentPixelsClickThroughRadius * view.getScaleX());
 
+        //The eventX and Y without border
+        int imageNoBorderEventX = eventX - borderRect.left;
+        int imageNoBorderventY = eventY - borderRect.top;
+
+        if(!imageRect.contains(imageNoBorderEventX, imageNoBorderventY)){
+            return false;
+        }
+
         //The eventX and Y for the actual image (discluding the frame and any views around it)
         int imageEventX = eventX - (imageRect.left + borderRect.left);
         int imageEventY = eventY - (imageRect.top + borderRect.top);


### PR DESCRIPTION
- The issue was partly that the rootView scale was huge on some devices. But the key problem was that we did not take into account the border when calculating if the imageRect contained the event X and Y.